### PR TITLE
Add explicit V1 scope statement near the intent_hash definition in ...

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3351,6 +3351,18 @@ Two agents — one in Python using `json.dumps`, one in Rust using `serde_cbor` 
 
 **Implementor guidance:** A delegation chain where every `intent_hash` verifies is audit-clean (no intermediary tampered with intent) but is not necessarily semantically correct (the preserved intent may not cover the downstream execution). V1 implementations MUST NOT treat successful `intent_hash` verification as proof of authorization compliance.
 
+#### V1 Scope: Intent Payload Schema Is Implementation-Defined
+
+> **V1 mandates `intent_hash` as a tamper-evident commitment field. The schema of the preimage — what gets hashed — is implementation-defined in V1.** No specific intent payload schema is normatively required.
+
+The protocol requires that `intent_hash` exist and be computed over the intent context fields (`intent`, `scope`, `constraints`) using the canonicalization rules in §6.4.1. However, V1 does not mandate the internal structure of those fields. The `intent` field may be a free-form string, a structured object with typed sub-fields, or any other JSON-serializable value. The same applies to `scope` and `constraints`. Two spec-compliant V1 implementations may use entirely different internal representations for these fields.
+
+**Recommendation:** Implementations SHOULD use a structured intent representation that includes at minimum: action type (what operation is being delegated), target resource (what the operation acts on), and constraints (bounds on how the operation may be performed). Structured representations improve auditability and lay groundwork for V2 interoperability. However, this is advisory — no specific schema is mandated by V1.
+
+**Interoperability consequence:** Because the intent payload schema is implementation-defined, two V1 agents from different implementations cannot semantically compare or interpret each other's intent fields — they can only verify that the hash commitment is intact. Cross-agent intent semantic interoperability requires a shared intent vocabulary: a common schema and value space that all participants agree on for interpreting intent fields. This is deferred to V2, where a shared intent vocabulary will be defined.
+
+> Addresses [issue #229](https://github.com/agent-collab-protocol/agent-collab-protocol/issues/229): explicit V1 scope statement that the intent payload schema is implementation-defined. References #229.
+
 #### intent_hash Computation
 
 `intent_hash` is the SHA-256 hash of the delegation intent context. The intent context is the concatenation of the following fields from the task schema (§6.1), canonicalized per §4.10:


### PR DESCRIPTION
## Summary
Add explicit V1 scope statement near the intent_hash definition in §6 stating that the payload schema is implementation-defined in V1. The spec defines intent_hash as a hash commitment over task intent but does not state what the preimage schema must be. Add a scope note making this explicit: V1 commits only to the field existing as a tamper-evident commitment; the schema of what gets hashed is implementation-defined. Implementations SHOULD include structured intent representation (action type, target resource, constraints) but no specific schema is mandated. Cross-agent intent semantic interoperability is deferred to V2 where a shared intent vocabulary will be defined. References issue #229.

Added '#### V1 Scope: Intent Payload Schema Is Implementation-Defined' subsection to §6.4.1, between the existing tamper-evidence scope note and the intent_hash Computation section. The new subsection explicitly states that V1 mandates intent_hash as a commitment field but the schema of the preimage is implementation-defined, recommends structured intent representation (SHOULD), and defers cross-agent intent semantic interoperability to V2. References issue #229.

## Files Modified
- SPEC.md

**Files Changed:** 1

---
🤖 This PR was created autonomously by Axioma
